### PR TITLE
#161678503 Ensure that a user cannot edit other user profiles.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -16,4 +16,5 @@ omit =
     */wsgi.py
     */.vscode/*
     */tests/*
+    */manage.py
 

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -1,16 +1,17 @@
 import re
 import time
 import jwt
-from django.conf import settings
 
-from rest_framework import status, generics, permissions
+from django.conf import settings
+from rest_framework import status
+from rest_framework import generics
+from rest_framework import permissions
 from rest_framework.response import Response
 from rest_framework.exceptions import APIException
 
 from .models import Article
 from .renderers import ArticleRenderer
 from .serializers import ArticleSerializer
-from authors.apps.authentication.models import User
 
 
 class ArticlesListCreateAPIView(generics.ListCreateAPIView):
@@ -48,7 +49,6 @@ class ArticlesListCreateAPIView(generics.ListCreateAPIView):
             elif i == ' ':
                 slug += '-'
 
-        # Add a timestamp if the slag alread exists
         if Article.objects.filter(slug=slug).exists():
             slug += str(time.time()).replace('.', '')
 

--- a/authors/apps/profiles/admin.py
+++ b/authors/apps/profiles/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-# Register your models here.

--- a/authors/apps/profiles/exceptions.py
+++ b/authors/apps/profiles/exceptions.py
@@ -1,0 +1,6 @@
+from rest_framework.exceptions import APIException
+
+
+class UserCannotEditProfile(APIException):
+    status_code = 403
+    default_detail = "Sorry, you cannot edit another users profile "

--- a/authors/apps/profiles/views.py
+++ b/authors/apps/profiles/views.py
@@ -1,25 +1,30 @@
+import jwt
+
 from django.shortcuts import get_object_or_404
+from django.conf import settings
 
 from rest_framework import status
-from rest_framework import serializers
-from rest_framework.generics import RetrieveUpdateAPIView, ListAPIView
-from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.generics import GenericAPIView, ListAPIView
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 
 from .models import Profile, User
 from .serializers import ProfileSerializer
 from .renderers import ProfileJSONRenderer
+from .exceptions import UserCannotEditProfile
 
 
-class ProfileRetrieveUpdateAPIView(RetrieveUpdateAPIView):
-    """Allow users  to retrieve and edit their profiles Params: username: A username is needed in order to get a specific profile.
-     """
+class ProfileRetrieveUpdateAPIView(GenericAPIView):
+    """
+    Allow users  to retrieve and edit their profiles Params: username:
+    A username is needed in order to get a specific profile.
+    """
     permission_classes = (IsAuthenticated,)
     renderer_classes = (ProfileJSONRenderer,)
     serializer_class = ProfileSerializer
 
-    def retrieve(self, request, username, *args, **kwargs):
+    def get(self, request, username, *args, **kwargs):
 
         user = get_object_or_404(User, username=username)
 
@@ -27,14 +32,26 @@ class ProfileRetrieveUpdateAPIView(RetrieveUpdateAPIView):
 
         return Response(serializer.data, status=status.HTTP_200_OK)
 
-    def update(self, request, username, *args, **kwargs):
+    def put(self, request, username, *args, **kwargs):
 
         serializer_data = request.data.get('profiles', {})
         user = get_object_or_404(User, username=username)
+        try:
+            token = request.META.get('HTTP_AUTHORIZATION', " ").split(' ')[1]
+            payload = jwt.decode(token, settings.SECRET_KEY, 'utf-8')
+            username = payload['username']
+            if user.username != username:
+                raise UserCannotEditProfile
+        except Exception:
+            raise UserCannotEditProfile
 
         serializer_data = {
-            'first_name': serializer_data.get('first_name', request.user.profile.last_name),
-            'last_name': serializer_data.get('last_name', request.user.profile.last_name),
+            'first_name':
+            serializer_data.get('first_name',
+                                request.user.profile.last_name),
+            'last_name':
+            serializer_data.get('last_name',
+                                request.user.profile.last_name),
             'bio': serializer_data.get('bio', request.user.profile.bio),
             'image': serializer_data.get('image', request.user.profile.image)
         }


### PR DESCRIPTION
#### What does this PR do?
- Ensures that the logged in user can only edit his/her own profile 
#### Description of the task to be completed
- A user can only edit his/her own profile.
- The Profiles view can now only use Put but not both put and patch.
- Remove unused imports in the views file
#### How should this be manually tested?

- Run `python manage.py runserver` to run the server
In postman using:


To edit a user profile
If a logged in user tries to edit another's profile
url: `api/profiles/<rachael>`
```
Payload:
{  "profiles": {
        "username": "jude",
        "bio": "i am trying to edit Jude's profile",
        "image": "",
        "first_name": "Rachael",
        "last_name": "Nantale"
    }
   }
}
```
The user will get an error message

```
{
    "profiles": {
        "detail": "Sorry, you cannot edit another users profile "
    }
}
```
#### Relevant Pivotal Tracker stories
 [#161678503](https://www.pivotaltracker.com/story/show/161678503)