### PR TITLE
#162599900 Users can follow each other by username

### DIFF
--- a/authors/apps/authentication/urls.py
+++ b/authors/apps/authentication/urls.py
@@ -27,14 +27,14 @@ urlpatterns = [
 
     # follow: POST /api/users/<id>/follow
     # Unfollow: DELETE /api/users/<id>/follow
-    path('users/<int:pk>/follow',
+    path('users/<str:username>/follow',
          FollowGenericAPIView.as_view()),
 
     # see followers GET /api/users/<id>/followers
-    path('users/<int:pk>/followers',
+    path('users/<str:username>/followers',
          FollowersListAPIView.as_view()),
 
     # see users one is following GET /api/users/<id>/following
-    path('users/<int:pk>/following',
+    path('users/<str:username>/following',
          FollowingListAPIView.as_view())
 ]

--- a/authors/apps/profiles/tests/test_profile.py
+++ b/authors/apps/profiles/tests/test_profile.py
@@ -158,7 +158,7 @@ class ProfileApiTestCase(UserBaseTestCase):
     def test_follow_another_user(self):
         """Test whether user A (current user) can follow user B"""
         user_b = User.objects.all().last()
-        res = self.client.post("/api/users/{}/follow".format(user_b.id),
+        res = self.client.post("/api/users/{}/follow".format(user_b.username),
                                {},
                                format='json')
         self.assertEqual(res.status_code, status.HTTP_201_CREATED)
@@ -167,7 +167,7 @@ class ProfileApiTestCase(UserBaseTestCase):
     def test_follow_oneself(self):
         """Test whether user A (current user) can follow themselves"""
         user_a = User.objects.all().first()
-        res = self.client.post("/api/users/{}/follow".format(user_a.id),
+        res = self.client.post("/api/users/{}/follow".format(user_a.username),
                                {},
                                format='json')
         self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
@@ -178,7 +178,7 @@ class ProfileApiTestCase(UserBaseTestCase):
         """Test wheter user A (current) can follow user B twice"""
         self.test_follow_another_user()
         user_b = User.objects.all().last()
-        res = self.client.post("/api/users/{}/follow".format(user_b.id),
+        res = self.client.post("/api/users/{}/follow".format(user_b.username),
                                {},
                                format='json')
         self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
@@ -197,8 +197,10 @@ class ProfileApiTestCase(UserBaseTestCase):
         """Test whether wheter user A (current) can unfollow user B"""
         self.test_follow_another_user()
         user_b = User.objects.all().last()
-        res = self.client.delete("/api/users/{}/follow".format(user_b.id),
-                                 format='json')
+        res = self.client.delete(
+            "/api/users/{}/follow".format(user_b.username),
+            format='json'
+        )
         self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertIn("You have Unfollowed the User", str(res.data))
 
@@ -206,8 +208,10 @@ class ProfileApiTestCase(UserBaseTestCase):
         """Test whether user A (current) can Unfollow user B twice"""
         self.test_unfollow_user()
         user_b = User.objects.all().last()
-        res = self.client.delete("/api/users/{}/follow".format(user_b.id),
-                                 format='json')
+        res = self.client.delete(
+            "/api/users/{}/follow".format(user_b.username),
+            format='json'
+        )
         self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
         self.assertIn("You are currently not following this user",
                       str(res.data))
@@ -226,7 +230,7 @@ class ProfileApiTestCase(UserBaseTestCase):
         """
         user_b = User.objects.all().last()
         res = self.client.get(
-            "/api/users/{}/following".format(user_b.id),
+            "/api/users/{}/following".format(user_b.username),
             format='json')
         self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
         self.assertIn("This user is not following anyone", str(res.data))
@@ -238,7 +242,7 @@ class ProfileApiTestCase(UserBaseTestCase):
         """
         user_a = User.objects.all().first()
         res = self.client.get(
-            "/api/users/{}/followers".format(user_a.id),
+            "/api/users/{}/followers".format(user_a.username),
             format='json')
         self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
         self.assertIn("This user is not being followed by anyone",


### PR DESCRIPTION
#### What does this PR do?
Ensures that users can follow each other given another user's `username`
#### Description of Task to be completed?
- Change follow by `id` to follow by `username`
- Repeat the behaviour for *"unfollow"*, *"view followers"*, and *"view user's you are following"*
#### How should this be manually tested?
POST: `/users/<username>/follow` - Follow a user
DELETE: `/users/<username>/follow` - UnFollow a user
GET: `/users/<username>/followers` - View followers
GET: `/users/<username>/following ` - View users you follow
#### Any background context you want to provide?
You must be logged in to perform any of the operations above
#### What are the relevant pivotal tracker stories?
[#162599900](https://www.pivotaltracker.com/story/show/162599900)